### PR TITLE
Update Contributing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-See [Contributing](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/contributing.md) for general information about coding styles, source structure, making pull requests, and more.
+See [Contributing]([https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/contributing.md](https://github.com/dotnet/runtime/blob/main/CONTRIBUTING.md)) for general information about coding styles, source structure, making pull requests, and more.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-See [Contributing]([https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/contributing.md](https://github.com/dotnet/runtime/blob/main/CONTRIBUTING.md)) for general information about coding styles, source structure, making pull requests, and more.
+See [Contributing](https://github.com/dotnet/runtime/blob/main/CONTRIBUTING.md) for general information about coding styles, source structure, making pull requests, and more.


### PR DESCRIPTION
The dotnet/coreclr repo is no longer active. Change the link to point to dotnet/runtime.